### PR TITLE
Changed error handling in newsletter

### DIFF
--- a/src/views/Newsletter/NewsletterPage.js
+++ b/src/views/Newsletter/NewsletterPage.js
@@ -20,7 +20,7 @@ export default function Newsletter() {
     useEffect(() => {
         const fetchData = async () => {
           let res = await integrate.getData(newsletterEndpoint, {});
-          if (res.data.resource.newsletter_content == undefined) window.location.reload();
+          if (res.data == undefined) window.location.reload();
           SetHtml(res.data.resource.newsletter_content);
         };
         fetchData();

--- a/src/views/Newsletter/NewsletterPage.js
+++ b/src/views/Newsletter/NewsletterPage.js
@@ -21,6 +21,7 @@ export default function Newsletter() {
         const fetchData = async () => {
           let res = await integrate.getData(newsletterEndpoint, {});
           if (res.data == undefined) window.location.reload();
+          if(res.data.resource.newsletter_content == undefined) window.location.reload();
           SetHtml(res.data.resource.newsletter_content);
         };
         fetchData();


### PR DESCRIPTION
Reload the page when we get no data from backend that is, if  `res.data`  is undefined, then page should reload